### PR TITLE
Date on Score

### DIFF
--- a/api/leaderboards.js
+++ b/api/leaderboards.js
@@ -139,6 +139,8 @@ var leaderboards = module.exports = {
         score.hash = md5([options.publickey, options.ip, options.table, options.playername, 
                           options.playerid, options.highest, options.source].join("."));
         score.points = options.points;
+	
+	score.date = datetime.now;
 		
         // check bans
 


### PR DESCRIPTION
Maybe my setup isn't configured right, but I always got the same date when submiting score (the date the server was restart). This fix it.